### PR TITLE
Updated metadata and removed unnecessary paragraphs

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -4,8 +4,8 @@
   <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async class='remove'></script>
   <script class="remove">
     var respecConfig = {
-      specStatus:          "ED", // "ED",
-      shortName:           "TV Control API Specification", // needed for generated URLs
+      specStatus:          "CG-DRAFT", // "ED",
+      shortName:           "tvapi", // needed for generated URLs
       editors: [{
         name: "SungHei Kim",
         company: "ETRI",
@@ -29,9 +29,9 @@
       previousMaturity:    "", // needed for "WD", "LC", "CR"
       lcEnd:               "", // needed for "LC"
       crEnd:               "", // needed for "CR"
-      // wg:           "System Applications Working Group",
-      // wgURI:        "http://www.w3.org/2012/sysapps/",
-      // wgPublicList: "public-sysapps",
+      wg:           "TV Control API Community Group",
+      wgURI:        "https://www.w3.org/community/tvapi/",
+      wgPublicList: "public-tvapi",
       // wgPatentURI:  "http://www.w3.org/2004/01/pp-impl/43696/status",
       otherLinks: [{
         key: "Version History",
@@ -64,30 +64,6 @@
     <p>
       <strong>Changes to this document may be tracked at
       <a href=https://github.com/w3c/tvapi>https://github.com/w3c/tvapi</a>.</strong>
-    </p>
-
-    <p>
-      The (<a href=http://lists.w3.org/Archives/Public/public-tvapi/>archived</a>)
-      public mailing list <a href="mailto:public-tvapi@w3.org">public-tvapi@w3.org</a>
-      (see <a href=http://www.w3.org/Mail/Request>instructions</a>)
-      is preferred for discussion of this specification.
-    </p>
-
-    <p>
-      This document was produced by the
-      <a href=http://www.w3.org/community/tvapi/>TV Control API CG</a>.
-    </p>
-
-    <p>
-      This document was produced by a group operating under the
-      <a href=http://www.w3.org/Consortium/Patent-Policy-20040205/>5 February 2004 W3C Patent Policy</a>.
-      W3C maintains a <a href=http://www.w3.org/2004/01/pp-impl/49309/status rel=disclosure>public list of any patent disclosures</a>
-      made in connection with the deliverables of the group; that page also
-      includes instructions for disclosing a patent. An individual who has
-      actual knowledge of a patent which the individual believes contains
-      <a href=http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential>Essential Claim(s)</a>
-      must disclose the information in accordance with
-      <a href=http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure>section 6 of the W3C Patent Policy</a>.
     </p>
   </section>
 


### PR DESCRIPTION
I've made the same changes for both `master` and `gh-pages` branches. This automates most of the Status section as well as provides formatting as a Community Group draft. Also, there are no patent disclosure obligations for CGs.